### PR TITLE
chore(cd): add Publish Package to GitHub Package Registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,34 +27,50 @@ jobs:
       - run: npm run build
       - name: Publish to NPM
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
 
           # Read version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "Current package version: $VERSION"
 
-          # Check if version contains prerelease marker (e.g., -rc, -beta, -alpha)
-          if [[ $VERSION == *"-"* ]]; then
-            # Extract prerelease tag (e.g., extract 'rc' from '1.0.0-rc.1')
-            PRERELEASE_TAG=$(echo $VERSION | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z]+).*/\1/')
-            echo "Detected prerelease version with tag: $PRERELEASE_TAG"
-
-            # Publish with the extracted tag
-            npm publish --tag $PRERELEASE_TAG --access public
-
-            echo "Published with tag: $PRERELEASE_TAG"
+          # Check if version already exists on npm
+          NPM_VIEW_OUTPUT=$(npm view @firefliesai/schema-forge@$VERSION 2>&1 || true)
+          if [[ $NPM_VIEW_OUTPUT != *"E404"* && $NPM_VIEW_OUTPUT != *"npm ERR! code E404"* ]]; then
+            echo "Version $VERSION already exists on npm registry. Skipping npm publish."
+            SKIP_NPM_PUBLISH="true"
           else
-            # Regular version, publish with default tag (latest)
-            npm publish --access public
-
-            echo "Published as latest version"
+            echo "Version $VERSION does not exist on npm registry. Proceeding with publish."
+            SKIP_NPM_PUBLISH="false"
           fi
+
+          # Only publish if version doesn't already exist
+          if [[ "$SKIP_NPM_PUBLISH" == "false" ]]; then
+            # Check if version contains prerelease marker (e.g., -rc, -beta, -alpha)
+            if [[ $VERSION == *"-"* ]]; then
+              # Extract prerelease tag (e.g., extract 'rc' from '1.0.0-rc.1')
+              PRERELEASE_TAG=$(echo $VERSION | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z]+).*/\1/')
+              echo "Detected prerelease version with tag: $PRERELEASE_TAG"
+
+              # Publish with the extracted tag
+              npm publish --tag $PRERELEASE_TAG --access public
+
+              echo "Published with tag: $PRERELEASE_TAG"
+            else
+              # Regular version, publish with default tag (latest)
+              npm publish --access public
+
+              echo "Published as latest version"
+            fi
+          fi
+
+          # Set output for GitHub Package Registry step
+          echo "SKIP_NPM_PUBLISH=${SKIP_NPM_PUBLISH}" >> $GITHUB_ENV
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create .npmrc file again
         run: |
-          rm .npmrc
+          rm -f .npmrc
           echo "@firefliesai:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${GTP_TOKEN}" >> .npmrc
       - name: Publish Package to GitHub Package Registry

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Deploy to NPM
+name: Deploy to NPM and GitHub Package Registry
 
 on:
   workflow_dispatch:
@@ -13,6 +13,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GTP_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -50,3 +51,15 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create .npmrc file again
+        run: |
+          rm .npmrc
+          echo "@firefliesai:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GTP_TOKEN}" >> .npmrc
+      - name: Publish Package to GitHub Package Registry
+        uses: JS-DevTools/npm-publish@v3.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          registry: https://npm.pkg.github.com/
+          package: ./package.json

--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ import { classToOpenAIResponseFormatJsonSchema } from '@firefliesai/schema-forge
 // Create a response format for OpenAI structured output
 const responseFormat = classToOpenAIResponseFormatJsonSchema(UserOutput, {
   forStructuredOutput: true,
-  strict: true
 });
 
 // Use with OpenAI


### PR DESCRIPTION
## What does this PR do?

xxx

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded the deployment process to publish packages to both NPM and the GitHub Package Registry.
	- Enhanced deployment steps now automatically configure registry authentication, ensuring a smoother delivery experience.
	- Added a check to skip publishing if the package version already exists on the NPM registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->